### PR TITLE
US12; completed registration email must be unique

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,9 @@ class UsersController < ApplicationController
       session[:user_id] = new_user.id
       flash[:success] = "You are now registered and logged in!"
       redirect_to '/profile'
+    elsif new_user.unique_email? 
+      flash[:error] = "This email is already in use! Please try again!!"
+      render :new
     else
       flash[:failure] = "You are missing fields, please fill in all fields to register!"
       redirect_to request.referer

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,9 @@ class User < ApplicationRecord
 
   validates_presence_of :password, require: true
   has_secure_password
+
+  def unique_email?
+    User.pluck(:email).include?(email)
+  end
+
 end

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -45,9 +45,50 @@ RSpec.describe "User Registration", type: :feature do
       fill_in :password_confirmation, with: "password"
 
       click_on "submit"
-      save_and_open_page
       expect(current_path).to eq('/register')
       expect(page).to have_content("You are missing fields, please fill in all fields to register!")
+    end
+
+    it "displays flash message saying email is duplicate" do
+      visit '/items'
+
+      within '.topnav' do
+        click_link "Register"
+      end
+
+      expect(current_path).to eq('/register')
+
+      fill_in :name, with: "Captain Jack"
+      fill_in :street_address, with: "123 Main Street"
+      fill_in :city, with: "Denver"
+      fill_in :state, with: "CO"
+      fill_in :zip, with: "11111"
+      fill_in :email, with: "c_j@email.com"
+      fill_in :password, with: "password"
+      fill_in :password_confirmation, with: "password"
+
+      click_on "submit"
+
+      visit '/items'
+
+      within '.topnav' do
+        click_link "Register"
+      end
+
+      expect(current_path).to eq('/register')
+
+      fill_in :name, with: "Don Juan"
+      fill_in :street_address, with: "124 Main Street"
+      fill_in :city, with: "Denver"
+      fill_in :state, with: "CO"
+      fill_in :zip, with: "11111"
+      fill_in :email, with: "c_j@email.com"
+      fill_in :password, with: "password"
+      fill_in :password_confirmation, with: "password"
+
+      click_on "submit"
+      expect(current_path).to eq('/register')
+      expect(page).to have_content("This email is already in use! Please try again!!")
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,5 @@ RSpec.describe User, type: :model do
     it {should validate_presence_of(:email)}
     it {should validate_uniqueness_of(:email)}
     it {should validate_presence_of(:password)}
-
   end
 end


### PR DESCRIPTION
User Story 12, Registration Email must be unique

As a visitor
When I visit the user registration page
If I fill out the registration form
But include an email address already in the system
Then I am returned to the registration page
My details are not saved and I am not logged in
The form is filled in with all previous data except the email field and password fields
I see a flash message telling me the email address is already in use