### PR TITLE
Logged in user user story 15

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,13 @@
 class SessionsController < ApplicationController
 
   def new
-  end
+    if session[:user_id] != nil
+      flash[:success] = "You are already logged in."
+      user = User.find(session[:user_id])
+      redirect_user
+      end
+    end
+
 
   def create
       user = User.find_by(email: params[:email])
@@ -16,12 +22,12 @@ class SessionsController < ApplicationController
   end
 
   def redirect_user
-      if current_user.role == "regular_user"
-        redirect_to '/profile'
-      elsif merchant?
-        redirect_to'/merchant'
-      else current_admin?
-        redirect_to '/admin'
-      end
+    if current_user.role == "regular_user"
+      redirect_to '/profile'
+    elsif merchant?
+      redirect_to'/merchant'
+    else current_admin?
+      redirect_to '/admin'
+    end
   end
 end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe "Items Index Page" do
       expect(page).to_not have_content("Inactive")
       expect(page).to_not have_content("Inventory: #{@dog_bone.inventory}")
       expect(page).to_not have_css("img[src*='#{@dog_bone.image}']")
-
     end
   end
 end

--- a/spec/features/users/login_spec.rb
+++ b/spec/features/users/login_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "User Registration", type: :feature do
       fill_in :email, with: user.email
       fill_in :password, with: user.password
       click_on "Login to Account"
-      expect(current_path).to eq("/merchant") #this need to be updated to meet us13 requirements
+      expect(current_path).to eq("/merchant")
     end
 
     it "cannot log in with bad credentials" do
@@ -30,6 +30,25 @@ RSpec.describe "User Registration", type: :feature do
 
       expect(current_path).to eq('/login')
       expect(page).to have_content("Sorry, your credentials are bad.")
+    end
+
+    it "can be redirected to correct path if already logged in" do
+      user = User.create(email: "funbucket13@gmail.com", password: "test", name: "Mike Dao", role: 1)
+
+      visit "/"
+      click_on "Login"
+
+      fill_in :email, with: user.email
+      fill_in :password, with: user.password
+
+      click_on "Login to Account"
+
+      expect(current_path).to eq('/merchant')
+
+      visit "/login"
+
+      expect(current_path).to eq('/merchant')
+      expect(page).to have_content("You are already logged in.")
     end
   end
 end


### PR DESCRIPTION
User Story 15, Users who are logged in already are redirected
- [x] done

As a registered user, merchant, or admin
When I visit the login path
  - [x] If I am a regular user, I am redirected to my profile page
  - [x] If I am a merchant user, I am redirected to my merchant dashboard page
  - [x] If I am an admin user, I am redirected to my admin dashboard page
  - [x] And I see a flash message that tells me I am already logged in