### PR TITLE
Display orders link

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,15 +531,15 @@ The show page template for an order can be shared between users, merchants and a
 - Admins can fulfill items on order on behalf of a merchant
 
 ```
-[ ] done
+[x] done
 
 User Story 27, User Profile displays Orders link
 
 As a registered user
 When I visit my Profile page
-And I have orders placed in the system
-Then I see a link on my profile page called "My Orders"
-When I click this link my URI path is "/profile/orders"
+- [x] And I have orders placed in the system
+- [x] Then I see a link on my profile page called "My Orders"
+- [x] When I click this link my URI path is "/profile/orders"
 ```
 
 ```

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,5 +9,7 @@
     <%= current_user.email %><br>
     <%= link_to "Edit My Info", "/profile/edit" %><br>
     <%= link_to "Edit My Password", "/profile/password" %><br>
+    <%= link_to "My Orders", "/profile/orders" %><br>
 
 </ul></h3>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   patch '/profile/password', to: "users#update_password"
 
   get '/profile', to: "users#show"
+  get '/profile/orders', to: "users#orders"
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,35 +1,86 @@
 require "rails_helper"
 
 RSpec.describe "User show page", type: :feature do
+  before :each do
+    #=== User
+    @user = User.create(email: "funbucket13@gmail.com", password: "test", name: "Mike Dao", street_address: "123 easy street", city: "Anycity", state: "Anystate", zip: 12345, role: 0)
+
+    #=== Merchants
+    @mike = Merchant.create(name: "Mike's Print Shop", address: '123 Paper Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+    
+    #=== Products
+    @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    @paper = @mike.items.create(name: "Lined Paper", description: "Great for writing on!", price: 20, image: "https://cdn.vertex42.com/WordTemplates/images/printable-lined-paper-wide-ruled.png", inventory: 3)
+    @pencil = @mike.items.create(name: "Yellow Pencil", description: "You can write on paper with it!", price: 2, image: "https://images-na.ssl-images-amazon.com/images/I/31BlVr01izL._SX425_.jpg", inventory: 100)
+
+    visit "/items/#{@paper.id}"
+    click_on "Add To Cart"
+    visit "/items/#{@paper.id}"
+    click_on "Add To Cart"
+    visit "/items/#{@tire.id}"
+    click_on "Add To Cart"
+    visit "/items/#{@pencil.id}"
+    click_on "Add To Cart"
+
+  end
   describe "As a user" do
     it "can login and see my info except for my password with a link to edit said data" do
-      user = User.create(email: "funbucket13@gmail.com",
-                        password: "test",
-                        name: "Mike Dao",
-                        street_address: "123 easy street",
-                        city: "Anycity",
-                        state: "Anystate",
-                        zip: 12345,
-                        role: 0)
-
       visit '/'
 
       click_on "Login"
 
       expect(current_path).to eq("/login")
 
-      fill_in :email, with: user.email
-      fill_in :password, with: user.password
+      fill_in :email, with: @user.email
+      fill_in :password, with: @user.password
 
       click_on "Login to Account"
       expect(current_path).to eq("/profile")
-      expect(page).to have_content("#{user.name}")
-      expect(page).to have_content("#{user.street_address}")
-      expect(page).to have_content("#{user.city}")
-      expect(page).to have_content("#{user.state}")
-      expect(page).to have_content("#{user.zip}")
-      expect(page).to have_content("#{user.email}")
+      expect(page).to have_content("#{@user.name}")
+      expect(page).to have_content("#{@user.street_address}")
+      expect(page).to have_content("#{@user.city}")
+      expect(page).to have_content("#{@user.state}")
+      expect(page).to have_content("#{@user.zip}")
+      expect(page).to have_content("#{@user.email}")
       expect(page).to have_link("Edit My Info")
     end
+
+    it "I see a link on my profile page called 'My Orders' When I click this link my URI path is '/profile/orders'" do
+      visit '/'
+      click_on "Login"
+      fill_in :email, with: @user.email
+      fill_in :password, with: @user.password
+      click_on "Login to Account"
+      expect(current_path).to eq("/profile")
+
+      visit "/cart"
+      click_on "Checkout"
+      
+      name = "Bert"
+      address = "123 Sesame St."
+      city = "NYC"
+      state = "New York"
+      zip = 10001
+
+      fill_in :name, with: name
+      fill_in :address, with: address
+      fill_in :city, with: city
+      fill_in :state, with: state
+      fill_in :zip, with: zip
+
+      click_button "Create Order"
+      click_on "Profile"
+      
+      ## Then I see a link on my profile page called "My Orders"
+      expect(page).to have_link("My Orders")
+      ## When I click this link my URI path is "/profile/orders"
+      click_on "My Orders"
+      expect(current_path).to eq("/profile/orders")
+
+      # save_and_open_page
+
+    end
+
   end
 end


### PR DESCRIPTION
### User Story 27, User Profile displays Orders link

As a registered user
When I visit my Profile page
- [x] And I have orders placed in the system
- [x] Then I see a link on my profile page called "My Orders"
- [x] When I click this link my URI path is "/profile/orders"
### The story doesn't include the controller action 'orders'. Needs to be added in story 28 &#x1F534;