### PR TITLE
US:22 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,10 @@ class UsersController < ApplicationController
     if current_user.save
       flash[:notice] = "Successfully updated your information!"
       redirect_to "/profile"
+    elsif
+      current_user.unique_email?
+        flash[:error] = "This email is already in use! Please try again!!"
+        redirect_to "/profile/edit"
     else
       flash[:error] = "Please fill in all fields."
       redirect_to request.referer
@@ -52,6 +56,7 @@ class UsersController < ApplicationController
   def edit_password
     current_user
   end
+
 
   private
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -11,7 +11,7 @@
     <%= label_tag "Zip Code: " %>
     <%= text_field_tag :zip, current_user.zip %>
     <%= label_tag "Email Address: " %>
-    <%= text_field_tag :email, current_user.email%>
+    <%= text_field_tag :email, current_user.email %>
     <%= hidden_field_tag :password, current_user.password_digest %>
 
     <%= submit_tag 'Submit Changes', class: :button %>

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "User show page", type: :feature do
         end
 
         it "I can't have mismatching passwords" do
-          
+
           user = User.create(email: "funbucket13@gmail.com",
                             password: "test",
                             name: "Mike Dao",
@@ -213,6 +213,49 @@ RSpec.describe "User show page", type: :feature do
           expect(current_path).to eq("/profile/password")
           expect(page).to have_content("Please have matching fields before submission.")
         end
+      end
+
+      it "User Editing Profile Data must have unique Email address" do
+        user = User.create(email: "funbucket13@gmail.com",
+                          password: "test",
+                          name: "Mike Dao",
+                          street_address: "123 easy street",
+                          city: "Anycity",
+                          state: "Anystate",
+                          zip: 12345,
+                          role: 0)
+        user2 = User.create(email: "funbucket12@gmail.com",
+                          password: "test123",
+                          name: "Mike Do",
+                          street_address: "1222 ez street",
+                          city: "Anycity",
+                          state: "Anystate",
+                          zip: 12345,
+                          role: 0)
+
+        visit '/'
+        click_on "Login"
+
+        fill_in :email, with: user.email
+        fill_in :password, with: user.password
+
+        click_on "Login to Account"
+        visit "/profile"
+
+        click_link "Edit My Info"
+
+
+        fill_in :name, with: user.name
+        fill_in :street_address, with: user.street_address
+        fill_in :city, with: user.city
+        fill_in :state, with: user.state
+        fill_in :zip, with: user.zip
+        fill_in :email, with: user2.email
+
+        click_on "Submit Changes"
+
+        expect(current_path).to eq("/profile/edit")
+        expect(page).to have_content("This email is already in use! Please try again!!")
       end
     end
   end


### PR DESCRIPTION
### User Story 22, User Editing Profile Data must have unique Email address
- [x] done

As a registered user
When I attempt to edit my profile data
If I try to change my email address to one that belongs to another user
When I submit the form
  - [x] Then I am returned to the profile edit page
  - [x] And I see a flash message telling me that email address is already in use