### PR TITLE
Complete US35

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -25,6 +25,8 @@ class Merchant <ApplicationRecord
     item_orders.distinct.joins(:order).pluck(:city)
   end
 
-
+  def pending_orders
+    Order.joins(:items).distinct.where(items: {merchant_id: id}).where(status: 'pending')
+  end
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,16 +1,27 @@
 class Order <ApplicationRecord
   belongs_to :user
-  
+
   has_many :item_orders
   has_many :items, through: :item_orders
   validates_presence_of :name, :address, :city, :state, :zip
-  
+
   enum status: [ :pending, :packaged, :shipped, :cancelled ]
 
   def grandtotal
     item_orders.sum('price * quantity')
   end
+
   def total_items
     item_orders.sum(:quantity)
   end
+
+  def quantity_for_merchant(merchant_id)
+    item_orders.joins(:item).where(items: {merchant_id: merchant_id}).sum(:quantity)
+  end
+
+  def total_for_merchant(merchant_id)
+    item_orders.joins(:item).where(items: {merchant_id: merchant_id}).sum('item_orders.quantity * item_orders.price')
+  end
+
+
 end

--- a/app/views/merchant/dashboard/show.html.erb
+++ b/app/views/merchant/dashboard/show.html.erb
@@ -3,3 +3,15 @@
 <h2>City: <%= @merchant.city %></h2>
 <h2>State: <%= @merchant.state %></h2>
 <h2>Zip: <%= @merchant.zip %></h2>
+
+<h3>Pending Orders</h3>
+<section id="pending-orders">
+  <% @merchant.pending_orders.each do |order| %>
+    <li id="order-<%= order.id %>">
+      <ul>Order link: <%= link_to order.id, "/merchant/orders/#{order.id}" %></ul>
+      <ul>Order made on: <%= order.created_at %></ul>
+      <ul>Quantity Ordered: <%= order.quantity_for_merchant(@merchant.id) %></ul>
+      <ul>Total Price: <%= number_to_currency(order.total_for_merchant(@merchant.id)) %></ul>
+    </li>
+  <% end %>
+</section>

--- a/spec/features/merchant/show_spec.rb
+++ b/spec/features/merchant/show_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe "Merchant Show Page", type: :feature do
     before :each do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 23137)
       @user = @bike_shop.users.create(name: "Mike Dao", street_address: "blah", city: "blah", state: "blah", zip: 12345, email: "blah@email.com", password: "test", role: 1)
+      @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break", price: 40, inventory: 12, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588")
+      @user_1 = User.create(email: "c_j@email.com", password: "test", name: "Meg", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 0)
+      @user_2 = User.create(email: "c@email.com", password: "test", name: "Mark", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 0)
+
+      @order_1 = @user_1.orders.create!(name: 'Meg', address: '123 Stang Ave', city: 'Hershey', state: 'PA', zip: 17033)
+      @order_2 = @user_2.orders.create!(name: 'Mark', address: '123 Stang Ave', city: 'Owego', state: 'NY', zip: 13811)
+      @order_1.item_orders.create!(item: @tire, price: @tire.price, quantity: 2)
+      @order_2.item_orders.create!(item: @chain, price: @tire.price, quantity: 4)
     end
 
     it "can see name and full address of the merchant I work for" do
@@ -30,18 +39,30 @@ RSpec.describe "Merchant Show Page", type: :feature do
 
     end
 
+    it "can see a list of pending orders" do
+      visit '/'
+
+      click_on "Login"
+
+
+      fill_in :email, with: @user.email
+      fill_in :password, with: @user.password
+      click_on "Login to Account"
+      click_on 'Dashboard'
+
+      within "#order-#{@order_1.id}" do
+        expect(page).to have_link("#{@order_1.id}")
+        expect(page).to have_content(@order_1.created_at)
+        expect(page).to have_content(@order_1.quantity_for_merchant(@bike_shop.id))
+        expect(page).to have_content(@order_1.total_for_merchant(@bike_shop.id))
+      end
+
+      within "#order-#{@order_2.id}" do
+        expect(page).to have_link("#{@order_2.id}")
+        expect(page).to have_content(@order_2.created_at)
+        expect(page).to have_content(@order_2.quantity_for_merchant(@bike_shop.id))
+        expect(page).to have_content(@order_2.total_for_merchant(@bike_shop.id))
+      end
+    end
   end
-
-
-#     User Story 35, Merchant Dashboard displays Orders
-#
-# As a merchant employee
-# When I visit my merchant dashboard ("/merchant")
-# If any users have pending orders containing items I sell
-# Then I see a list of these orders.
-# Each order listed includes the following information:
-# - the ID of the order, which is a link to the order show page ("/merchant/orders/15")
-# - the date the order was made
-# - the total quantity of my items in the order
-# - the total value of my items for that order
 end

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "As a visitor" do
       visit "/items/#{pencil.id}"
       click_on "Add To Cart"
 
-      user = User.create(email: "c_j@email.com", password: "test", name: "Mike Dao", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 1)      
+      user = mike.users.create(email: "c_j@email.com", password: "test", name: "Mike Dao", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 1)      
       visit '/'
       click_on "Login"
       fill_in :email, with: user.email

--- a/spec/features/users/login_spec.rb
+++ b/spec/features/users/login_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe "User Registration", type: :feature do
   describe "As a visitor" do
     it "can login" do
-      user = User.create(email: "c_j@email.com", password: "test", name: "Mike Dao", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 1)
+      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 23137)
+      user = bike_shop.users.create(email: "c_j@email.com", password: "test", name: "Mike Dao", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 1)
 
       visit '/'
 
@@ -33,7 +34,8 @@ RSpec.describe "User Registration", type: :feature do
     end
 
     it "can be redirected to correct path if already logged in" do
-      user = User.create(email: "c_j@email.com", password: "test", name: "Mike Dao", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 1)
+      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 23137)
+      user = bike_shop.users.create(email: "c_j@email.com", password: "test", name: "Mike Dao", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 1)
 
       visit "/"
       click_on "Login"

--- a/spec/features/users/logout_spec.rb
+++ b/spec/features/users/logout_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Logout" do
     it "can logout" do
       bike_shop = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       @tire = bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-      user = User.create(name: "John Doe", street_address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "funbucket13@gmail.com", password: "test", role: 1)
+      user = bike_shop.users.create(name: "John Doe", street_address: "123 Main Street", city: "Anytown", state: "Anystate", zip: 123456, email: "funbucket13@gmail.com", password: "test", role: 1)
 
       visit "/"
       click_on "Login"


### PR DESCRIPTION
User Story 35, Merchant Dashboard displays Orders

As a merchant employee
When I visit my merchant dashboard ("/merchant")
If any users have pending orders containing items I sell
Then I see a list of these orders.
Each order listed includes the following information:
- the ID of the order, which is a link to the order show page ("/merchant/orders/15")
- the date the order was made
- the total quantity of my items in the order
- the total value of my items for that order