### PR TITLE
Complete user story 40

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -9,11 +9,17 @@ class Admin::MerchantsController < Admin::BaseController
     @merchant = Merchant.find(params[:id])
   end
 
-  def disable_merchant
+  def update
     @merchant = Merchant.find(params[:id])
-    @merchant.disable
-    flash[:success] = "This merchant has been disabled."
-    redirect_to '/admin/merchants'
+    if params[:disable_enable] == 'enable'
+      @merchant.enable
+      flash[:success] = "This merchant is now enabled."
+      redirect_to '/admin/merchants'
+    else
+      @merchant.disable
+      flash[:success] = "This merchant has been disabled."
+      redirect_to '/admin/merchants'
+    end
   end
 
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -31,6 +31,7 @@ class Merchant <ApplicationRecord
 
   def disable
     update(disabled: true)
+    items.update_all(active?: false)
   end
 
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -29,6 +29,11 @@ class Merchant <ApplicationRecord
     Order.joins(:items).distinct.where(items: {merchant_id: id}).where(status: 'pending')
   end
 
+  def enable
+    update(disabled: false)
+    # items.update_all(active?: false)
+  end
+
   def disable
     update(disabled: true)
     items.update_all(active?: false)

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,6 +1,10 @@
 <h1><%= @merchants.each do |merchant| %></h1>
   <section id="merchant-<%= merchant.id %>">
     <p><%= link_to merchant.name, "/admin/merchant/#{merchant.id}" %></p>
-    <p><%= button_to 'Disable', "/admin/merchants/#{merchant.id}/disable", method: :patch, id: 'inline-form', form: { id: 'inline-form' } %></p>
+    <p> <% if merchant.disabled %>
+          <%= button_to 'Enable', "/admin/merchants/#{merchant.id}/enable", method: :patch, id: 'inline-form', form: { id: 'inline-form' } %>
+      <% else %>
+          <%= button_to 'Disable', "/admin/merchants/#{merchant.id}/disable", method: :patch, id: 'inline-form', form: { id: 'inline-form' } %>
+    <% end %></p>
   </section>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index'
     resources :merchants, only: [:index, :show]
     get '/merchant/:id', to: 'merchants#show'
-    patch '/merchants/:id/:disable', to: 'merchants#disable_merchant'
+    patch '/merchants/:id/:disable_enable', to: 'merchants#update'
     #resources :users, only: [:index]
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -65,5 +65,34 @@ RSpec.describe "Admin merchant index", type: :feature do
         expect(page).to_not have_content(@tire.name)
         expect(page).to_not have_content(@chain.name)
       end
+
+      it "I can see an enable button next to the merchant and click it" do
+        visit '/'
+        click_on "Login"
+        expect(current_path).to eq("/login")
+
+        fill_in :email, with: @user.email
+        fill_in :password, with: @user.password
+        click_on "Login to Account"
+        click_on "All Merchants"
+        expect(page).to have_content(@bike_shop.name)
+
+        within "#merchant-#{@bike_shop.id}" do
+          click_on "Disable"
+          expect(current_path).to eq('/admin/merchants')
+        end
+
+        within "#merchant-#{@bike_shop.id}" do
+          expect(page).to have_button('Enable')
+        end
+
+        within "#merchant-#{@bike_shop.id}" do
+          click_on "Enable"
+          expect(current_path).to eq('/admin/merchants')
+        end
+
+        expect(page).to have_content("This merchant is now enabled.")
+        save_and_open_page  
+      end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Admin merchant index", type: :feature do
   before(:each) do
     @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 23137)
     @user = User.create(email: "c_j@email.com", password: "test", name: "Meg", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 2)
+    @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break", price: 40, inventory: 12, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588")
   end
   describe "As an admin" do
     it "I can see a disable button next to any merchants" do
@@ -38,6 +40,30 @@ RSpec.describe "Admin merchant index", type: :feature do
         end
 
         expect(page).to have_content("This merchant has been disabled.")
+      end
+
+      it "A disabled merchant's items are also disabled" do
+        visit '/'
+        visit '/items'
+        expect(page).to have_content(@tire.name)
+        expect(page).to have_content(@chain.name)
+        click_on "Login"
+        expect(current_path).to eq("/login")
+
+        fill_in :email, with: @user.email
+        fill_in :password, with: @user.password
+        click_on "Login to Account"
+        click_on "All Merchants"
+
+        within "#merchant-#{@bike_shop.id}" do
+          click_on "Disable"
+          expect(current_path).to eq('/admin/merchants')
+        end
+
+        visit '/items'
+
+        expect(page).to_not have_content(@tire.name)
+        expect(page).to_not have_content(@chain.name)
       end
   end
 end


### PR DESCRIPTION
#### User Story 40, Admin enables a merchant account
- [x] done

As an admin
When I visit the merchant index page
- [x] I see an "enable" button next to any merchants whose accounts are disabled
When I click on the "enable" button
- [x] I am returned to the admin's merchant index page 
- [x] where I see that the merchant's account is now enabled
- [x] And I see a flash message that the merchant's account is now enabled