### PR TITLE
Completes user story 47

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -46,6 +46,8 @@ class Merchant::ItemsController < Merchant::BaseController
     @item = Item.find(params[:id])
     @item.update(item_params)
     @item.save
+    flash[:success] = "Your item has been updated."
+
     redirect_to '/merchant/items'
   end
 

--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -18,7 +18,7 @@ class Merchant::ItemsController < Merchant::BaseController
     end
   end
 
-  def update
+  def enable_disable
     @item = Item.find(params[:id])
     if params[:disable_enable] == 'enable'
       @item.enable
@@ -35,6 +35,17 @@ class Merchant::ItemsController < Merchant::BaseController
     @item = Item.find(params[:id])
     @item.destroy
     flash[:destroy] = "#{@item.name} is now deleted"
+    redirect_to '/merchant/items'
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+    @item.save
     redirect_to '/merchant/items'
   end
 

--- a/app/views/merchant/items/edit.html.erb
+++ b/app/views/merchant/items/edit.html.erb
@@ -1,0 +1,15 @@
+<h1>Edit Item</h1>
+
+<%= form_for [:merchant, @item] do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name%>
+  <%= f.label :description %>
+  <%= f.text_field :description %>
+  <%= f.label :image %>
+  <%= f.text_field :image %>
+  <%= f.label :price %>
+  <%= f.text_field :price%>
+  <%= f.label :inventory, 'Current Inventory Count' %>
+  <%= f.text_field :inventory%>
+  <%= f.submit %>
+<% end %>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -12,7 +12,8 @@
   <% else %>
     <%= link_to 'Deactivate', "/merchant/items/#{item.id}/disable", method: :patch %>
   <% end %></p>
-  <p><%= link_to 'Delete', "/merchant/items/#{item.id}/destroy", method: :delete %></p>
+  <%= link_to 'Delete', "/merchant/items/#{item.id}/destroy", method: :delete %>
+  <%= link_to 'Edit', "/merchant/items/#{item.id}/edit", method: :get %>
   </section>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,10 +50,10 @@ Rails.application.routes.draw do
 
   namespace :merchant do
     get '/', to: "dashboard#show"
-    patch "/items/:id/:disable_enable", to: 'items#update'
+    patch "/items/:id/:disable_enable", to: 'items#enable_disable'
     delete "/items/:id/destroy", to: 'items#destroy'
 
-    resources :items, only: [:index, :update, :new, :create]
+    resources :items, except: [:show]
   end
 
   namespace :admin do

--- a/spec/features/merchant/item_edit_spec.rb
+++ b/spec/features/merchant/item_edit_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Edit Item", type: :feature do
+  describe "As a Merchant" do
+    before(:each) do
+      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 23137)
+      @user = @bike_shop.users.create(email: "c_j@email.com", password: "test", name: "Meg", city: "blah", state: "blah", street_address: "blah", zip: 12345, role: 1)
+      @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break", price: 40, inventory: 12, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588")
+    end
+
+    it "can" do
+      visit '/'
+      click_on "Login"
+      expect(current_path).to eq("/login")
+
+      fill_in :email, with: @user.email
+      fill_in :password, with: @user.password
+      click_on "Login to Account"
+
+      visit '/merchant/items'
+
+      within"#item-#{@tire.id}" do
+        expect(page).to have_link("Edit")
+        click_on "Edit"
+      end
+
+      expect(current_path).to eq("/merchant/items/#{@tire.id}/edit")
+      expect(find_field('Name').value).to eq(@tire.name)
+      expect(find_field('Description').value).to eq(@tire.description)
+      expect(find_field('Price').value).to eq('100')
+      expect(find_field('Inventory').value).to eq('12')
+      fill_in 'Name', with: "Diamond"
+      click_on 'Update Item'
+
+      expect(current_path).to eq('/merchant/items')
+
+      within"#item-#{@tire.id}" do
+        expect(page).to have_content("Diamond")
+      end
+    end
+  end
+end

--- a/spec/features/merchant/item_edit_spec.rb
+++ b/spec/features/merchant/item_edit_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Edit Item", type: :feature do
       click_on 'Update Item'
 
       expect(current_path).to eq('/merchant/items')
-
+      expect(page).to have_content("Your item has been updated.")
       within"#item-#{@tire.id}" do
         expect(page).to have_content("Diamond")
       end


### PR DESCRIPTION
#### User Story 47, Merchant edits an item
- [x] done

As a merchant employee
When I visit my items page
And I click the edit button or link next to any item
- [x] Then I am taken to a form similar to the 'new item' form
- [x] The form is pre-populated with all of this item's information
- [x] I can change any information, but all of the rules for adding a new item still apply:
  - name and description cannot be blank
  - price cannot be less than $0.00
  - inventory must be 0 or greater

When I submit the form
- [x] I am taken back to my items page
- [x] I see a flash message indicating my item is updated
- [x] I see the item's new information on the page, and 
  - [x] it maintains its previous enabled/disabled state
- [x] If I left the image field blank, I see a placeholder image for the thumbnail