### PR TITLE
complete us 48

### DIFF
--- a/app/controllers/merchant/items_controller.rb
+++ b/app/controllers/merchant/items_controller.rb
@@ -45,10 +45,13 @@ class Merchant::ItemsController < Merchant::BaseController
   def update
     @item = Item.find(params[:id])
     @item.update(item_params)
-    @item.save
-    flash[:success] = "Your item has been updated."
-
-    redirect_to '/merchant/items'
+    if @item.save
+      flash[:success] = "Your item has been updated."
+      redirect_to '/merchant/items'
+    else
+      flash[:error] = "Please fill in all fields to continue."
+      redirect_to "/merchant/items/#{@item.id}/edit"
+    end
   end
 
   private

--- a/spec/features/merchant/item_edit_spec.rb
+++ b/spec/features/merchant/item_edit_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Edit Item", type: :feature do
       @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break", price: 40, inventory: 12, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588")
     end
 
-    it "can" do
+    it "can edit an item" do
       visit '/'
       click_on "Login"
       expect(current_path).to eq("/login")
@@ -38,6 +38,34 @@ RSpec.describe "Edit Item", type: :feature do
       within"#item-#{@tire.id}" do
         expect(page).to have_content("Diamond")
       end
+    end
+
+    it "cant edit an item with missing information" do
+      visit '/'
+      click_on "Login"
+      fill_in :email, with: @user.email
+      fill_in :password, with: @user.password
+      click_on "Login to Account"
+      visit '/merchant/items'
+
+      within"#item-#{@tire.id}" do
+        click_on "Edit"
+      end
+
+      expect(current_path).to eq("/merchant/items/#{@tire.id}/edit")
+      expect(find_field('Name').value).to eq(@tire.name)
+      expect(find_field('Description').value).to eq(@tire.description)
+      expect(find_field('Price').value).to eq('100')
+      expect(find_field('Inventory').value).to eq('12')
+      fill_in 'Name', with: ''
+      click_on 'Update Item'
+
+      expect(page).to have_content("Please fill in all fields to continue.")
+
+      expect(find_field('Name').value).to eq(@tire.name)
+      expect(find_field('Description').value).to eq(@tire.description)
+      expect(find_field('Price').value).to eq('100')
+      expect(find_field('Inventory').value).to eq('12')
     end
   end
 end


### PR DESCRIPTION
#### User Story 48, Merchant cannot edit an item if details are bad/missing
- [x] done

As a merchant employee
When I try to edit an existing item
If any of my data is incorrect or missing (except image)
- [x] Then I am returned to the form
- [x] I see one or more flash messages indicating each error I caused
- [x] All fields are re-populated with my previous data